### PR TITLE
Fix for osx build - unknown warning option -Wformat-signedness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ debian/debhelper-build-stamp
 debian/files
 .DS_Store
 .vscode/
+public_html/data/

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ debian/.debhelper
 debian/dump1090-fa*
 debian/debhelper-build-stamp
 debian/files
+.DS_Store
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROGNAME=dump1090
 DUMP1090_VERSION ?= unknown
 
 CFLAGS ?= -O3 -g
-DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -Wformat-signedness -W
+DUMP1090_CFLAGS := -std=c11 -fno-common -Wall -Wmissing-declarations -Werror -W
 DUMP1090_CPPFLAGS := -I. -D_POSIX_C_SOURCE=200112L -DMODES_DUMP1090_VERSION=\"$(DUMP1090_VERSION)\" -DMODES_DUMP1090_VARIANT=\"dump1090-fa\"
 
 LIBS = -lpthread -lm


### PR DESCRIPTION
fixes https://github.com/flightaware/dump1090/issues/236

```
error: unknown warning option '-Wformat-signedness' [-Werror,-Wunknown-warning-option]
make: *** [dump1090.o] Error 1
```